### PR TITLE
Add live editing and normalize package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ utility in their use.
 ElementsProject.org is a static website powered by [Hexo](https://hexo.io).
 You'll need `npm` (which comes with Node.js) to get started.
 
-First, install hexo: `npm install hexo-cli -g`
-
 Fork the repository (top right hand corner on GitHub), and get a local copy:
 ```
 git clone git@github.com:YOUR_USERNAME/elementsproject.org # clone the repo
 cd elementsproject.org # move into the directory
 ```
 
+Next, install the dependancies using `npm install`
+
 Now, you can use Hexo to run a local copy to preview your changes:
 ```
-hexo server
+npm start
 ```
 
 That's it.  Make modifications, commit them, and submit a pull request.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "hexo-site",
+  "name": "elementsproject.org",
   "version": "2.8.3",
   "private": true,
+  "scripts": {
+    "start": "hexo server"
+  },
   "hexo": {
-    "version": "3.1.1"
+    "version": "3.2.0"
   },
   "dependencies": {
     "hexo": "^3.1.0",
+    "hexo-browsersync": "^0.2.0",
     "hexo-generator-archive": "^0.1.2",
     "hexo-generator-category": "^0.1.2",
     "hexo-generator-index": "^0.1.2",
@@ -17,5 +21,14 @@
     "hexo-renderer-marked": "^0.2.4",
     "hexo-renderer-stylus": "^0.3.0",
     "hexo-server": "^0.1.2"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ElementsProject/elementsproject.org/issues"
+  },
+  "homepage": "https://github.com/ElementsProject/elementsproject.org#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ElementsProject/elementsproject.org.git"
   }
 }


### PR DESCRIPTION
Resolves #18 

We're using browsersync instead of livereload because the livereload module for hexo is broken.

Additionally, expands package.json with appropriate links and license information.