### PR TITLE
Testnet addresses can also start with n

### DIFF
--- a/source/sidechains/alpha/getting-started.md
+++ b/source/sidechains/alpha/getting-started.md
@@ -191,7 +191,7 @@ faucet] for this purpose; let's get our Bitcoin address and request some funds:
 ```bash
 ../bitcoin-cli -testnet -rpcuser=user -rpcpassword=pass getnewaddress
 ```
-You'll get an output of an address – make sure it starts with an `m`, which
+You'll get an output of an address – make sure it starts with an `m` or an `n`, which
 designates a testnet address–and plug that into [the `testnet3` bitcoin faucet
 ][testnet faucet] to request some coins.
 


### PR DESCRIPTION
The documentation instructs you to make sure your testnet address starts with an `m`. They can also start with `n` according to https://en.bitcoin.it/wiki/List_of_address_prefixes