### PR TITLE
Remove a now-useless fetch-merge

### DIFF
--- a/source/sidechains/creating-your-own.md
+++ b/source/sidechains/creating-your-own.md
@@ -52,8 +52,6 @@ Run testnet. If you get an error asking to rebuild the blockchain, replace `-txi
 Checkout the `alpha` branch.
 ```shell
 git checkout alpha
-git fetch https://github.com/TomMcCabe/elements patch
-git merge FETCH_HEAD alpha
 ```
 
 With bitcoin testnet, generate an address and obtain the private/public key.


### PR DESCRIPTION
Comments/instructions were removed in this [commit](https://github.com/TomMcCabe/elementsproject.org/commit/4c1c9ee3bb4353c8cd6fda0898e831f8af4565b8), but not the fetch-merge.