### PR TITLE
Updated the Elements build instructions in creating-your-own page

### DIFF
--- a/source/sidechains/creating-your-own.md
+++ b/source/sidechains/creating-your-own.md
@@ -14,7 +14,7 @@ Deterministic Peg Element](/elements/deterministic-peg.html) for more details.
 
 #### Prerequisites
 You'll need a working version of Elements.  Follow [the Elements build
-instructions](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md)
+instructions](https://github.com/ElementsProject/elements/blob/elements-0.14.1/doc/build-unix.md)
 to get set up.
 
 ### Creating your own blockchain


### PR DESCRIPTION
The Elements build instructions hyperlink is outdated, it points to bitcoin repo, it should point to this link https://github.com/ElementsProject/elements/blob/elements-0.14.1/doc/build-unix.md